### PR TITLE
Allow pos/ end to match within a range

### DIFF
--- a/bam_to_contig/bam_to_contig.sh
+++ b/bam_to_contig/bam_to_contig.sh
@@ -1,6 +1,6 @@
 #!/bin/env bash
-python $1 $2 $3 | \
+python $1 $2 $3 $4 | \
 sort -k1,1 -k2,2n | \
 bedtools merge -d 20 | \
-awk -v flank="$4" '{ $2=($2-flank<0)?0:$2-flank; $3=$3+flank } 1' | \
+awk -v flank="0" '{ $2=($2-flank<0)?0:$2-flank; $3=$3+flank } 1' | \
 sed 's/ /:/; s/ /-/'

--- a/bam_to_contig/bam_to_contig.wdl
+++ b/bam_to_contig/bam_to_contig.wdl
@@ -87,7 +87,7 @@ task RunBamToContig {
       disk_gb:            10,
       boot_disk_gb:       10,
       preemptible_tries:  1,
-      max_retries:        1,
+      max_retries:        0,
       docker: "us.gcr.io/broad-dsp-lrma/lr-talon:5.0"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
@@ -126,7 +126,7 @@ task RunFaidx {
       disk_gb:            10,
       boot_disk_gb:       10,
       preemptible_tries:  1,
-      max_retries:        1,
+      max_retries:        0,
       docker: "us.gcr.io/broad-dsp-lrma/lr-talon:5.0"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
@@ -163,7 +163,7 @@ task ConcatContigs {
       disk_gb:            10,
       boot_disk_gb:       10,
       preemptible_tries:  1,
-      max_retries:        1,
+      max_retries:        0,
       docker: "us.gcr.io/broad-dsp-lrma/lr-talon:5.0"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])

--- a/bam_to_contig/make_contig_bed.py
+++ b/bam_to_contig/make_contig_bed.py
@@ -4,6 +4,7 @@ import pysam
 
 in_bam = sys.argv[1]
 gene_region_bed = sys.argv[2]
+ref_pos_end_buffer = int(sys.argv[3])  # find closest matching contig start/ end coord to reference coord, within this buffer
 
 with open(gene_region_bed) as f:
     chrom, ref_pos, ref_end = f.readline().strip().split('\t')
@@ -15,16 +16,22 @@ for r in s.fetch(reference=chrom, start=ref_pos, end=ref_end):
     is_rev_strand = r.flag & 0x10 != 0
     ctg_start = None
     ctg_end = None
+    start_min_dist = ref_pos_end_buffer
+    end_min_dist = ref_pos_end_buffer
+
     for ctg_coord, ref_coord in r.get_aligned_pairs():
         if ref_coord is None:
             continue
         # assume sorted
-        if ref_coord == ref_pos:
-            ctg_start = ctg_coord
-        elif ref_coord == ref_end:
+        if abs(ref_coord - ref_pos) <= start_min_dist:
+            ctg_start = ctg_coord  # closest position to the start position in the bed, within buffer
+            start_min_dist = abs(ref_coord - ref_pos)
+        elif abs(ref_coord - ref_end) <= end_min_dist:
             ctg_end = ctg_coord
-    assert ctg_start is not None and ctg_end is not None
-    if is_rev_strand:
-        print(f"{r.query_name}/rc\t{r.query_length - ctg_end}\t{r.query_length - ctg_start}\n")
-    else:
-        print(f"{r.query_name}\t{ctg_start}\t{ctg_end}\n")
+            end_min_dist = abs(ref_coord - ref_end)
+
+    if ctg_start is not None and ctg_end is not None:
+        if is_rev_strand:
+            print(f"{r.query_name}/rc\t{r.query_length - ctg_end - 1}\t{r.query_length - ctg_start}\n")
+        else:
+            print(f"{r.query_name}\t{ctg_start}\t{ctg_end}\n")

--- a/bam_to_contig/make_contig_bed.py
+++ b/bam_to_contig/make_contig_bed.py
@@ -4,33 +4,30 @@ import pysam
 
 in_bam = sys.argv[1]
 gene_region_bed = sys.argv[2]
-ref_pos_end_buffer = int(sys.argv[3])  # find closest matching contig start/ end coord to reference coord, within this buffer
+locus_buffer = int(sys.argv[3])
 
 with open(gene_region_bed) as f:
-    chrom, ref_pos, ref_end = f.readline().strip().split('\t')
-ref_pos = int(ref_pos)
-ref_end = int(ref_end)
-    
+    chrom, locus_pos, locus_end = f.readline().strip().split('\\t')
+locus_pos = int(locus_pos)
+locus_end = int(locus_end)
+locus_pos_buffered = locus_pos - locus_buffer
+locus_end_buffered = locus_end + locus_buffer
+
 s = pysam.AlignmentFile(in_bam, "rb")  # 1000151-asm_h1.minimap2.bam
-for r in s.fetch(reference=chrom, start=ref_pos, end=ref_end):
+for r in s.fetch(reference=chrom, start=locus_pos_buffered, end=locus_end_buffered):
     is_rev_strand = r.flag & 0x10 != 0
-    ctg_start = None
-    ctg_end = None
-    start_min_dist = ref_pos_end_buffer
-    end_min_dist = ref_pos_end_buffer
+    all_pairs = [p for p in r.get_aligned_pairs() if (
+        (p[1] is not None) and (p[1] >= locus_pos_buffered) and (p[1] <= locus_end_buffered)
+    )]  # ctg, ref pairs within locus + buffer
+    if not all_pairs:
+        continue
+    all_ref = [z[1] for z in all_pairs]
+    all_ctg = [z[0] for z in all_pairs if z[0] is not None]
 
-    for ctg_coord, ref_coord in r.get_aligned_pairs():
-        if ref_coord is None:
-            continue
-        # assume sorted
-        if abs(ref_coord - ref_pos) <= start_min_dist:
-            ctg_start = ctg_coord  # closest position to the start position in the bed, within buffer
-            start_min_dist = abs(ref_coord - ref_pos)
-        elif abs(ref_coord - ref_end) <= end_min_dist:
-            ctg_end = ctg_coord
-            end_min_dist = abs(ref_coord - ref_end)
-
-    if ctg_start is not None and ctg_end is not None:
+    if locus_pos in all_ref and locus_end in all_ref:  # locus contained in contig
+        # first and last contig coord in locus + buffer
+        ctg_start = all_ctg[0]
+        ctg_end = all_ctg[-1]
         if is_rev_strand:
             print(f"{r.query_name}/rc\t{r.query_length - ctg_end - 1}\t{r.query_length - ctg_start}\n")
         else:


### PR DESCRIPTION
Instead of requiring exact pos and end for reference locus to map in alignment to a contig, allow a range